### PR TITLE
Handle .pb filenames and paths dynamically in PbFileFetcher

### DIFF
--- a/aa/pb.py
+++ b/aa/pb.py
@@ -296,14 +296,6 @@ class PbFileFetcher(fetcher.Fetcher):
     def __init__(self, root):
         self._root = root
 
-    def _get_pb_file(self, pv, year):
-        # Split PV on either dash or colon
-        parts = re.split("[-:]", pv)
-        suffix = parts.pop()
-        directory = os.path.join(self._root, os.path.sep.join(parts))
-        filename = "{}:{}.pb".format(suffix, year)
-        return os.path.join(directory, filename)
-
     def _create_datetime_for_pb_file(self, filepath):
         filename = os.path.basename(filepath)
         # the filename can contain only the year or stepwise more info up to year, month, day, hour and minutes

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -297,11 +297,17 @@ class PbFileFetcher(fetcher.Fetcher):
         self._root = root
 
     def _create_datetime_for_pb_file(self, filepath):
-        """Each .pb files of the archiver appliance ends with a date information corresponding to the stored data.
-        This function returns a datetime.datetime object matching the date information of the given .pb file."""
+        """Each .pb files of the archiver appliance ends with a date information
+        corresponding to the stored data. This function returns a datetime.datetime
+        object matching the date information of the given .pb file."""
         filename = os.path.basename(filepath)
-        # The filename can contain only the year or stepwise more info up to year, month, day, hour and minutes.
-        dates = re.search(r"\d{4}(_\d{2})?(_\d{2})?(_\d{2})?(_\d{2})?", filename).group(0).split('_')
+        # The filename can contain only the year or stepwise more info up to year,
+        # month, day, hour and minutes.
+        dates = (
+            re.search(r"\d{4}(_\d{2})?(_\d{2})?(_\d{2})?(_\d{2})?", filename)
+            .group(0)
+            .split("_")
+        )
         dates = [int(date) for date in dates]
         # Make sure to give a least 3 arguments to datetime.datetime.
         while len(dates) < 3:
@@ -309,9 +315,10 @@ class PbFileFetcher(fetcher.Fetcher):
         return datetime.datetime(*dates, tzinfo=pytz.utc)
 
     def _get_pb_files(self, pv, start, end):
-        """Instead of looking only in the LTS for yearly generated .pb files, this function goes through all
-        LTS/MTS/STS directories and returns all .pb files containing data of the specified time window. The 
-        granularity setup of the archiver for LTS/MTS/STS can also deviate from the standard one."""
+        """Instead of looking only in the LTS for yearly generated .pb files, this
+        function goes through all LTS/MTS/STS directories and returns all .pb files
+        containing data of the specified time window. The granularity setup of the
+        archiver for LTS/MTS/STS can also deviate from the standard one."""
         # Dynamically find the correct path to the pb files.
         # Strip any STS/MTS/LTS from the root first to ensure backwards compatibility.
         if os.path.basename(os.path.normpath(self._root)) in ["STS", "MTS", "LTS"]:
@@ -344,7 +351,7 @@ class PbFileFetcher(fetcher.Fetcher):
             end_index = 1
         if start_index == end_index:
             end_index += 1
-        return pv_files[start_index : end_index]
+        return pv_files[start_index:end_index]
 
     @staticmethod
     def _read_pb_files(files, pv, start, end, count):

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -294,7 +294,9 @@ class PbFetcher(fetcher.AaFetcher):
 
 class PbFileFetcher(fetcher.Fetcher):
     def __init__(self, roots):
-        self._roots = list(roots)
+        if isinstance(roots, str):
+            roots = [roots]
+        self._roots = roots
 
     def _get_all_pb_files_of_pv(self, pv):
         """Returns a list of all .pb files of the given PV which are found under the
@@ -320,11 +322,7 @@ class PbFileFetcher(fetcher.Fetcher):
         filename = os.path.basename(filepath)
         # The filename can contain just the year or stepwise more information up to
         # year, month, day, hour and minutes.
-        dates = (
-            re.search(r"\d{4}(_\d{2}){0,4}", filename)
-            .group(0)
-            .split("_")
-        )
+        dates = re.search(r"\d{4}(_\d{2}){0,4}", filename).group(0).split("_")
         if dates is None:
             log.warning(
                 "File path does not contain date information in expected format."

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -318,14 +318,14 @@ class PbFileFetcher(fetcher.Fetcher):
         # Dynamically find the correct path to the pb files.
         # Therefore, strip any STS/MTS/LTS first.
         if os.path.basename(os.path.normpath(self._root)) in ["STS", "MTS", "LTS"]:
-            root = os.path.dirname(os.path.normpath(self._root))
+            self._root = os.path.dirname(os.path.normpath(self._root))
         # get all files for this pv
         pv_files = []
         # Split PV on either dash or colon
         parts = re.split("[-:]", pv)
         suffix = parts.pop()
         for s in ["LTS", "MTS", "STS"]:
-            directory = os.path.join(root, s, os.path.sep.join(parts))
+            directory = os.path.join(self._root, s, os.path.sep.join(parts))
             for f in sorted(glob.glob(os.path.join(directory, f"{suffix}*pb"))):
                 pv_files.append(f)
         pv_files_datetime = [self._create_datetime_for_pb_file(f) for f in pv_files]

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -318,8 +318,8 @@ class PbFileFetcher(fetcher.Fetcher):
         corresponding to the stored data. This function returns a datetime.datetime
         object matching the date information of the given .pb file."""
         filename = os.path.basename(filepath)
-        # The filename can contain only the year or stepwise more info up to year,
-        # month, day, hour and minutes.
+        # The filename can contain just the year or stepwise more information up to
+        # year, month, day, hour and minutes.
         dates = (
             re.search(r"\d{4}(_\d{2})?(_\d{2})?(_\d{2})?(_\d{2})?", filename)
             .group(0)
@@ -332,15 +332,15 @@ class PbFileFetcher(fetcher.Fetcher):
         return datetime.datetime(*dates, tzinfo=pytz.utc)
 
     def _get_pb_files(self, pv, start, end=None):
-        """Instead of looking only in the LTS for yearly generated .pb files, this
-        function goes through all LTS/MTS/STS directories and returns all .pb files
+        """Goes through LTS/MTS/STS directories of given PV and returns all .pb files
         containing data of the specified time window. The granularity setup of the
-        archiver for LTS/MTS/STS can also deviate from the standard one."""
+        archiver for LTS/MTS/STS can deviate from the standard one."""
         if end is None:
             end = datetime.datetime.now().astimezone(pytz.utc)
+            log.info("No end time given, assuming now() in UTC.")
         if start > end:
             start, end = end, start
-            log.warning("Start date was after end date. Swapped them.")
+            log.warning("End date was before start date. Swapped them.")
         pv_files = self._get_all_pb_files_of_pv(pv)
         pv_files_datetime = [self._create_datetime_for_pb_file(f) for f in pv_files]
         # Find the files we need between start and end.

--- a/aa/pb.py
+++ b/aa/pb.py
@@ -339,19 +339,21 @@ class PbFileFetcher(fetcher.Fetcher):
             if file_date > start and start_index is None:
                 start_index = i - 1
             if file_date > end and end_index is None:
-                end_index = i - 1
+                end_index = i
         # Ensure sound indices.
         if start_index is None:
-            start_index = 0
+            start_index = len(pv_files) - 1
         if end_index is None:
             end_index = len(pv_files)
         if start_index < 0:
             start_index = 0
-        if end_index < 0:
-            end_index = 1
         if start_index == end_index:
             end_index += 1
-        return pv_files[start_index:end_index]
+        # Only return files matching the time window.
+        pb_files = pv_files[start_index:end_index]
+        if len(pb_files) == 0:
+            log.warning("No pb file found for PV {}".format(pv))
+        return pb_files
 
     @staticmethod
     def _read_pb_files(files, pv, start, end, count):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -134,7 +134,15 @@ def test_warning_logged_by_ArchiveData_constructor_if_timestamps_descending(
 
 
 # Test both ascending array and constant array.
-@pytest.mark.parametrize("timestamps", (numpy.arange(1, 2, 0.1), numpy.ones(10,)))
+@pytest.mark.parametrize(
+    "timestamps",
+    (
+        numpy.arange(1, 2, 0.1),
+        numpy.ones(
+            10,
+        ),
+    ),
+)
 def test_ArchiveData_constructor_raises_no_exception_if_timestamps_valid(
     dummy_pv, timestamps
 ):

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -71,9 +71,7 @@ def test_JsonFetcher_decodes_waveform_events_correctly(
     assert aa_data == data_2d_2_events
 
 
-def test_JsonFetcher_decodes_enum_events_correctly(
-    dummy_pv, json_fetcher,
-):
+def test_JsonFetcher_decodes_enum_events_correctly(dummy_pv, json_fetcher):
     enum_json = utils.load_from_file("enum_event.json")
     mock_response = utils.mock_response(json_str=enum_json)
     json_fetcher._fetch_data = mock.MagicMock(return_value=mock_response)

--- a/tests/test_pb.py
+++ b/tests/test_pb.py
@@ -162,6 +162,26 @@ def test_PbFileFetcher_get_all_pb_files_of_pv():
         assert fetcher._get_all_pb_files_of_pv(pv) == dummy_files
 
 
+def test_PbFileFetcher_get_all_pb_files_of_pv_handels_pv_with_two_colons():
+    dummy_files = [
+        "root/LTS/a/b/c/d_2001.pb",
+        "root/MTS/a/b/c/d_2001_02_03.pb",
+        "root/STS/a/b/c/d_2001_02_03_04.pb",
+    ]
+
+    def side_effect(path_pv_dir):
+        for i, s in enumerate(["LTS", "MTS", "STS"]):
+            if s in path_pv_dir:
+                return [dummy_files[i]]
+
+    with mock.patch("glob.glob") as mock_glob:
+        mock_glob.side_effect = side_effect
+        root = "root"
+        pv = "a-b:c:d"
+        fetcher = pb.PbFileFetcher(root)
+        assert fetcher._get_all_pb_files_of_pv(pv) == dummy_files
+
+
 def test_PbFileFetcher_create_datetime_for_pb_file():
     root = "root"
     filepath = os.path.join("root", "a", "b", "c", "d:2001_02_03_04_05.pb")

--- a/tests/test_pb.py
+++ b/tests/test_pb.py
@@ -156,7 +156,7 @@ def test_PbFileFetcher_get_all_pb_files_of_pv():
 
     with mock.patch("glob.glob") as mock_glob:
         mock_glob.side_effect = side_effect
-        root = "root"
+        root = "root/LTS/"
         pv = "a-b-c:d"
         fetcher = pb.PbFileFetcher(root)
         assert fetcher._get_all_pb_files_of_pv(pv) == dummy_files


### PR DESCRIPTION
The current version is limited to the usage of only the .pb files in the LTS and in addition it requires that the granularity is set to yearly, resulting in a filename which ends with the four digits of the year (_yyyy.pb). As our archiver appliance for the Belle II PXD is setup with a granularity of one file per month in the LTS (_yyyy_mm.pb), I needed a modification. This proposal now does not only cope for our specific case but should be able to find all required files for a PV across LTS, MTS and STS independently of the configured granularity of the archiver.

As far as I understand this patch completely keeps backwards compatibility.

Changes in tests/test_data.py and tests/test_js.py were only made to satisfy flake8/black rule checker.

I added several test functions to tests/test_pb.py which helped me to fix the logic of _get_pb_files(). But I'm pretty new to pytest and especially to mocking, so I guess there might be better solutions to avoid duplicated code.

Thank you very much in advance for your comments!